### PR TITLE
refactor: Don't use @nuxtjs/dotenv

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,8 +2,6 @@ import fs from 'fs';
 import YAML from 'yaml';
 import webpack from 'webpack';
 
-require('dotenv').config();
-
 function readYamlFile(filePath) {
   const file = fs.readFileSync(filePath, 'utf8');
 
@@ -73,8 +71,6 @@ export default {
     '@nuxtjs/stylelint-module',
     // https://windicss.org/guide/
     'nuxt-windicss',
-    // https://github.com/nuxt-community/dotenv-module
-    '@nuxtjs/dotenv',
     // https://www.npmjs.com/package/@nuxtjs/style-resources
     '@nuxtjs/style-resources',
     ['@nuxtjs/eslint-module', { fix: true }],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
-    "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/eslint-config": "^6.0.1",
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/stylelint-module": "^4.0.0",


### PR DESCRIPTION
Nuxt 2.13 + is already prepacked with dot .env variables and also introduce using  runtime config , check https://nuxtjs.org/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config/