### PR TITLE
feat(auth): user impersonation + ability seeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test-results/
 
 # Claude Code skill sources (cloned via pnpm skills:sync; symlinked into .claude/skills)
 .claude/skill-sources/
+.vercel

--- a/app/api/useAuthApi.ts
+++ b/app/api/useAuthApi.ts
@@ -1,6 +1,18 @@
+import type { AuthUser } from '~~/server/utils/auth'
+
+export interface ImpersonationCandidate {
+  id: string
+  username: string | null
+  name: string | null
+  primary_email: string
+  avatar: string | null
+  abilities: string[]
+  is_suspended: boolean | null
+}
+
 export function useAuthApi() {
   function fetchCurrentUser() {
-    return $http('/api/auth/me')
+    return $http<AuthUser>('/api/auth/me')
   }
 
   function updateCurrentUser(data: { name: string }) {
@@ -33,6 +45,23 @@ export function useAuthApi() {
     })
   }
 
+  function fetchImpersonationCandidates() {
+    return $http<ImpersonationCandidate[]>('/api/auth/impersonate/users')
+  }
+
+  function startImpersonation(userId: string) {
+    return $http<AuthUser>('/api/auth/impersonate/start', {
+      method: 'POST',
+      body: { user_id: userId },
+    })
+  }
+
+  function stopImpersonation() {
+    return $http<AuthUser>('/api/auth/impersonate/stop', {
+      method: 'POST',
+    })
+  }
+
   function logout() {
     return $http('/api/auth/logout')
   }
@@ -43,6 +72,9 @@ export function useAuthApi() {
     fetchUserNotificationSettings,
     updateUserNotificationSettings,
     updatePhoneNumber,
+    fetchImpersonationCandidates,
+    startImpersonation,
+    stopImpersonation,
     logout,
   }
 }

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,7 @@
 <template>
   <UApp>
     <NuxtRouteAnnouncer />
+    <ImpersonationBanner />
     <NuxtPage />
   </UApp>
 </template>

--- a/app/components/ImpersonationBanner.vue
+++ b/app/components/ImpersonationBanner.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+const authStore = useAuthStore()
+const toast = useToast()
+const isStopping = ref(false)
+
+async function stop() {
+  isStopping.value = true
+  try {
+    await authStore.stopImpersonation()
+    toast.add({ title: 'Stopped impersonation', color: 'success' })
+    await navigateTo('/sandbox/impersonate')
+  }
+  catch (err: unknown) {
+    const error = err as { statusCode?: number, statusMessage?: string }
+    toast.add({
+      title: 'Stop impersonation failed',
+      description: error?.statusMessage ?? 'Unknown error',
+      color: 'error',
+    })
+  }
+  finally {
+    isStopping.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="authStore.isImpersonating && authStore.impersonator"
+    class="bg-warning text-inverted px-4 py-2 flex items-center justify-between gap-4"
+    data-testid="global-impersonation-banner"
+  >
+    <div class="flex items-center gap-2 text-sm">
+      <UIcon name="i-lucide-user-cog" class="size-4" />
+      <span>
+        Impersonating
+        <strong>{{ authStore.currentUser?.name ?? authStore.currentUser?.primary_email }}</strong>
+        as <strong>{{ authStore.impersonator.name }}</strong>
+      </span>
+    </div>
+    <UButton
+      size="xs"
+      color="neutral"
+      variant="solid"
+      icon="i-lucide-log-out"
+      :loading="isStopping"
+      data-testid="banner-stop-impersonation"
+      @click="stop"
+    >
+      Stop
+    </UButton>
+  </div>
+</template>

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+definePageMeta({ unauthenticatedOnly: true })
+useHead({ title: 'Sign in' })
+
+const config = useRuntimeConfig()
+const isDemo = computed(() => Boolean(config.public.demoMode))
+
+const authStore = useAuthStore()
+const toast = useToast()
+const busy = ref<'admin' | 'user' | null>(null)
+
+async function signInAsDemoAgent(agent: 'admin' | 'user') {
+  busy.value = agent
+  try {
+    await $fetch('/api/auth/demo-login', { method: 'POST', body: { agent } })
+    await authStore.fetchCurrentUser()
+    toast.add({
+      title: agent === 'admin' ? 'Signed in as Admin Agent' : 'Signed in as User Agent',
+      color: 'success',
+    })
+    await navigateTo(agent === 'admin' ? '/sandbox/impersonate' : '/')
+  }
+  catch (err: unknown) {
+    const error = err as { statusCode?: number, statusMessage?: string }
+    toast.add({
+      title: 'Demo sign-in failed',
+      description: error?.statusMessage ?? 'Unknown error',
+      color: 'error',
+    })
+  }
+  finally {
+    busy.value = null
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center px-4 py-16 bg-default">
+    <UCard class="w-full max-w-md" data-testid="login-card">
+      <template #header>
+        <div class="text-center space-y-2">
+          <UIcon name="i-lucide-log-in" class="size-8 mx-auto text-primary" />
+          <h1 class="text-2xl font-semibold text-highlighted">
+            Sign in
+          </h1>
+          <p class="text-sm text-muted">
+            Welcome back. Choose how you'd like to sign in.
+          </p>
+        </div>
+      </template>
+
+      <div v-if="isDemo" class="space-y-3" data-testid="demo-block">
+        <UAlert
+          color="warning"
+          variant="subtle"
+          icon="i-lucide-flask-conical"
+          title="Demo mode"
+          description="Sandbox deployment with seeded fake users. Do not use real credentials."
+        />
+
+        <UButton
+          block
+          size="lg"
+          color="primary"
+          icon="i-lucide-shield-check"
+          :loading="busy === 'admin'"
+          :disabled="busy !== null"
+          data-testid="signin-admin-agent"
+          @click="signInAsDemoAgent('admin')"
+        >
+          Sign in as Admin Agent
+        </UButton>
+
+        <UButton
+          block
+          size="lg"
+          color="neutral"
+          variant="outline"
+          icon="i-lucide-user"
+          :loading="busy === 'user'"
+          :disabled="busy !== null"
+          data-testid="signin-user-agent"
+          @click="signInAsDemoAgent('user')"
+        >
+          Sign in as User Agent
+        </UButton>
+
+        <p class="text-xs text-muted text-center pt-2">
+          Admin Agent has the <code>user:impersonate</code> ability.
+          User Agent does not.
+        </p>
+      </div>
+
+      <div v-else class="space-y-3 text-center">
+        <p class="text-sm text-muted">
+          OAuth providers haven't been wired up in this build.
+        </p>
+        <UButton
+          to="/api/auth/google"
+          external
+          block
+          size="lg"
+          icon="i-logos-google-icon"
+          color="neutral"
+          variant="outline"
+        >
+          Continue with Google
+        </UButton>
+        <UButton
+          to="/api/auth/github"
+          external
+          block
+          size="lg"
+          icon="i-logos-github-icon"
+          color="neutral"
+          variant="outline"
+        >
+          Continue with GitHub
+        </UButton>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/app/pages/sandbox/impersonate.vue
+++ b/app/pages/sandbox/impersonate.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import type { ImpersonationCandidate } from '~/api/useAuthApi'
+import { useAuthApi } from '~/api/useAuthApi'
+
+definePageMeta({ can: ['user:impersonate'] })
+useHead({ title: 'Impersonation sandbox' })
+
+const authApi = useAuthApi()
+const authStore = useAuthStore()
+const toast = useToast()
+
+const candidates = ref<ImpersonationCandidate[]>([])
+const loadError = ref<string | null>(null)
+const busyId = ref<string | null>(null)
+const isStopping = ref(false)
+
+async function loadCandidates() {
+  loadError.value = null
+  try {
+    candidates.value = await authApi.fetchImpersonationCandidates()
+  }
+  catch (err: unknown) {
+    const error = err as { statusCode?: number, statusMessage?: string }
+    loadError.value = error?.statusMessage ?? 'Failed to load users'
+    candidates.value = []
+  }
+}
+
+async function impersonate(user: ImpersonationCandidate) {
+  busyId.value = user.id
+  try {
+    await authStore.startImpersonation(user.id)
+    toast.add({ title: `Now impersonating ${user.name ?? user.primary_email}`, color: 'success' })
+  }
+  catch (err: unknown) {
+    const error = err as { statusCode?: number, statusMessage?: string }
+    toast.add({
+      title: 'Impersonation failed',
+      description: error?.statusMessage ?? 'Unknown error',
+      color: 'error',
+    })
+  }
+  finally {
+    busyId.value = null
+  }
+}
+
+async function stop() {
+  isStopping.value = true
+  try {
+    await authStore.stopImpersonation()
+    toast.add({ title: 'Stopped impersonation', color: 'success' })
+  }
+  catch (err: unknown) {
+    const error = err as { statusCode?: number, statusMessage?: string }
+    toast.add({
+      title: 'Stop impersonation failed',
+      description: error?.statusMessage ?? 'Unknown error',
+      color: 'error',
+    })
+  }
+  finally {
+    isStopping.value = false
+  }
+}
+
+await useAsyncData('impersonate-candidates', () => loadCandidates())
+</script>
+
+<template>
+  <UContainer class="py-12 max-w-3xl">
+    <div class="space-y-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-highlighted">
+          Impersonation sandbox
+        </h1>
+        <p class="text-muted">
+          Admins with the <code>user:impersonate</code> ability can sign in as
+          any other user. The Redis session swaps to the target so every
+          authorization check (server and client) reflects the impersonated
+          user.
+        </p>
+      </div>
+
+      <UCard>
+        <template #header>
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm text-muted">
+                Current session
+              </p>
+              <p class="font-semibold text-highlighted" data-testid="current-user-name">
+                {{ authStore.currentUser?.name ?? authStore.currentUser?.primary_email ?? 'Not signed in' }}
+              </p>
+              <p class="text-xs text-muted" data-testid="current-user-email">
+                {{ authStore.currentUser?.primary_email }}
+              </p>
+            </div>
+            <UBadge
+              v-if="authStore.isImpersonating"
+              color="warning"
+              variant="soft"
+              data-testid="impersonating-badge"
+            >
+              Impersonating
+            </UBadge>
+          </div>
+        </template>
+
+        <div v-if="authStore.currentUser" class="space-y-2">
+          <div>
+            <p class="text-xs text-muted">
+              Abilities
+            </p>
+            <div class="flex flex-wrap gap-1 mt-1">
+              <UBadge
+                v-for="a in authStore.currentUser.abilities"
+                :key="a"
+                color="neutral"
+                variant="subtle"
+                size="sm"
+              >
+                {{ a }}
+              </UBadge>
+              <span v-if="authStore.currentUser.abilities.length === 0" class="text-xs text-muted">
+                (none)
+              </span>
+            </div>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard
+        v-if="authStore.isImpersonating && authStore.impersonator"
+        data-testid="impersonator-card"
+      >
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-lucide-user-cog" class="size-4 text-warning" />
+            <p class="font-semibold text-highlighted">
+              Impersonator (real session)
+            </p>
+          </div>
+        </template>
+
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <p class="font-medium" data-testid="impersonator-name">
+              {{ authStore.impersonator.name }}
+            </p>
+            <p class="text-xs text-muted" data-testid="impersonator-email">
+              {{ authStore.impersonator.primary_email }}
+            </p>
+          </div>
+          <UButton
+            color="warning"
+            variant="solid"
+            icon="i-lucide-log-out"
+            :loading="isStopping"
+            data-testid="stop-impersonation"
+            @click="stop"
+          >
+            Stop impersonating
+          </UButton>
+        </div>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <p class="font-semibold text-highlighted">
+            Available users
+          </p>
+        </template>
+
+        <div v-if="loadError" class="text-sm text-error" data-testid="candidates-error">
+          {{ loadError }}
+        </div>
+        <div v-else-if="candidates.length === 0" class="text-center text-muted py-8">
+          No other users to impersonate.
+        </div>
+        <ul v-else class="divide-y divide-default" data-testid="candidates-list">
+          <li
+            v-for="user in candidates"
+            :key="user.id"
+            class="flex items-center gap-3 py-3"
+            :data-testid="`candidate-${user.primary_email}`"
+          >
+            <div class="flex-1">
+              <p class="font-medium">
+                {{ user.name ?? user.username ?? user.primary_email }}
+              </p>
+              <p class="text-xs text-muted">
+                {{ user.primary_email }} · {{ user.abilities.length }} abilities
+              </p>
+            </div>
+            <UButton
+              size="sm"
+              icon="i-lucide-user-check"
+              :loading="busyId === user.id"
+              :disabled="authStore.isImpersonating || !!user.is_suspended"
+              :data-testid="`impersonate-${user.primary_email}`"
+              @click="impersonate(user)"
+            >
+              Impersonate
+            </UButton>
+          </li>
+        </ul>
+      </UCard>
+    </div>
+  </UContainer>
+</template>

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,10 +1,16 @@
-import type { AuthUser } from '~~/server/utils/auth'
+import type { AuthUser, ImpersonatorInfo } from '~~/server/utils/auth'
 import { useAuthApi } from '~/api/useAuthApi'
 
 export const useAuthStore = defineStore('auth', () => {
   const currentUser = useState<AuthUser | null>('user', () => null)
 
   const authApi = useAuthApi()
+
+  const impersonator = computed<ImpersonatorInfo | null>(
+    () => currentUser.value?.impersonator ?? null,
+  )
+
+  const isImpersonating = computed(() => !!impersonator.value)
 
   async function fetchCurrentUser() {
     const currentUserData = await authApi.fetchCurrentUser()
@@ -20,6 +26,18 @@ export const useAuthStore = defineStore('auth', () => {
     return authApi.fetchUserNotificationSettings()
   }
 
+  async function startImpersonation(userId: string) {
+    const session = await authApi.startImpersonation(userId)
+    currentUser.value = session
+    return session
+  }
+
+  async function stopImpersonation() {
+    const session = await authApi.stopImpersonation()
+    currentUser.value = session
+    return session
+  }
+
   async function logout() {
     await authApi.logout()
 
@@ -28,9 +46,13 @@ export const useAuthStore = defineStore('auth', () => {
 
   return {
     currentUser,
+    impersonator,
+    isImpersonating,
     fetchCurrentUser,
     updateCurrentUser,
     fetchUserNotificationSettings,
+    startImpersonation,
+    stopImpersonation,
     logout,
   }
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -204,6 +204,8 @@ export default defineNuxtConfig({
       sslEnabled: false,
 
       baseDomain: 'localhost:3000',
+
+      demoMode: false,
     },
 
     // Vercel use CRON_SECRET as environment variable for scheduled functions, so we need to use it here as well

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:preview": "drizzle-kit studio",
+    "db:seed": "tsx ./scripts/seed.ts",
+    "db:seed:down": "tsx ./scripts/seed.ts down",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
@@ -73,6 +75,7 @@
     "magic-regexp": "^0.11.0",
     "nuxt-security": "^2.5.1",
     "playwright-core": "^1.59.1",
+    "tsx": "^4.21.0",
     "type-fest": "^5.5.0",
     "vitest": "^4.1.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       playwright-core:
         specifier: ^1.59.1
         version: 1.59.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       type-fest:
         specifier: ^5.5.0
         version: 5.5.0

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,86 @@
+import type { SeedUserDef } from '../shared/seed/users'
+import { config } from 'dotenv'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { userTable } from '../server/db/pg/schema'
+import { SEED_USERS } from '../shared/seed/users'
+
+config({
+  path: process.env.NODE_ENV === 'production' ? '.env.production' : '.env',
+})
+
+export { ABILITY_PRESETS, SEED_USERS } from '../shared/seed/users'
+
+export async function seedUsers(
+  db: ReturnType<typeof drizzle>,
+  users: SeedUserDef[] = SEED_USERS,
+) {
+  const seeded: Array<{ id: string, primary_email: string, abilities: string[] }> = []
+  for (const u of users) {
+    const existing = await db.select().from(userTable).where(eq(userTable.primary_email, u.primary_email)).limit(1)
+    if (existing[0]) {
+      const [updated] = await db.update(userTable)
+        .set({
+          username: u.username,
+          name: u.name,
+          primary_phone: u.primary_phone ?? null,
+          abilities: u.abilities,
+          verified: true,
+        })
+        .where(eq(userTable.id, existing[0].id))
+        .returning()
+      seeded.push({ id: updated!.id, primary_email: updated!.primary_email, abilities: updated!.abilities })
+    }
+    else {
+      const [created] = await db.insert(userTable).values({
+        primary_email: u.primary_email,
+        username: u.username,
+        name: u.name,
+        primary_phone: u.primary_phone ?? null,
+        abilities: u.abilities,
+        verified: true,
+      }).returning()
+      seeded.push({ id: created!.id, primary_email: created!.primary_email, abilities: created!.abilities })
+    }
+  }
+  return seeded
+}
+
+export async function unseedUsers(
+  db: ReturnType<typeof drizzle>,
+  users: SeedUserDef[] = SEED_USERS,
+) {
+  for (const u of users) {
+    await db.delete(userTable).where(eq(userTable.primary_email, u.primary_email))
+  }
+}
+
+async function main() {
+  const url = process.env.NUXT_POSTGRES_URL
+  if (!url) {
+    console.error('NUXT_POSTGRES_URL is not set; aborting seed.')
+    process.exit(1)
+  }
+  const db = drizzle(url)
+
+  const cmd = process.argv[2] ?? 'up'
+  if (cmd === 'down') {
+    await unseedUsers(db)
+    console.log(`Removed ${SEED_USERS.length} seed users.`)
+  }
+  else {
+    const seeded = await seedUsers(db)
+    for (const s of seeded) {
+      console.log(`Seeded ${s.primary_email} (id=${s.id}, abilities=[${s.abilities.join(', ')}])`)
+    }
+  }
+
+  process.exit(0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/server/api/auth/demo-login.post.ts
+++ b/server/api/auth/demo-login.post.ts
@@ -1,0 +1,93 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { ActivityAction, activityTable, userTable } from '~~/server/db/pg/schema'
+import { getPgClient } from '~~/server/utils/pg'
+import { ABILITY_PRESETS } from '~~/shared/seed/users'
+import { simplifyNanoId } from '~~/shared/utils/id'
+
+const DEMO_AGENTS = {
+  admin: {
+    email: 'admin@demo.local',
+    username: 'demo_admin',
+    name: 'Admin Agent',
+    abilities: [...ABILITY_PRESETS.admin],
+  },
+  user: {
+    email: 'user@demo.local',
+    username: 'demo_user',
+    name: 'User Agent',
+    abilities: [...ABILITY_PRESETS.member],
+  },
+} as const
+
+const DemoLoginSchema = z.object({
+  agent: z.enum(['admin', 'user']),
+})
+
+export default defineEventHandler(async (event) => {
+  if (!import.meta.dev && process.env.NUXT_DEMO_MODE !== 'true') {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const { agent } = await readValidatedBody(event, DemoLoginSchema.parse)
+  const preset = DEMO_AGENTS[agent]
+
+  const db = getPgClient()
+  const now = new Date()
+
+  const existing = await db.select().from(userTable).where(eq(userTable.primary_email, preset.email)).limit(1)
+
+  let user = existing[0]
+  if (!user) {
+    const [created] = await db.insert(userTable).values({
+      primary_email: preset.email,
+      username: preset.username,
+      name: preset.name,
+      abilities: preset.abilities,
+      verified: true,
+      last_sign_in_at: now,
+    }).returning()
+    user = created!
+    await db.insert(activityTable).values({ user_id: user.id, action: ActivityAction.SIGN_UP })
+  }
+  else {
+    const [updated] = await db.update(userTable)
+      .set({
+        username: preset.username,
+        name: preset.name,
+        abilities: preset.abilities,
+        verified: true,
+        last_sign_in_at: now,
+      })
+      .where(eq(userTable.id, user.id))
+      .returning()
+    user = updated!
+  }
+
+  const sessionId = simplifyNanoId()
+  const storage = useStorage('redis')
+
+  await storage.setItem(`session:${sessionId}`, {
+    id: user.id,
+    primary_email: user.primary_email,
+    primary_phone: user.primary_phone,
+    username: user.username,
+    name: user.name,
+    avatar: user.avatar,
+    verified: user.verified,
+    provider: 'demo',
+    abilities: user.abilities ?? [],
+  })
+
+  setCookie(event, 'sessionid', sessionId, {
+    httpOnly: true,
+    secure: !import.meta.dev,
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 7,
+    path: '/',
+  })
+
+  await db.insert(activityTable).values({ user_id: user.id, action: ActivityAction.SIGN_IN })
+
+  return { agent, user_id: user.id, primary_email: user.primary_email }
+})

--- a/server/api/auth/dev-cleanup.post.ts
+++ b/server/api/auth/dev-cleanup.post.ts
@@ -1,0 +1,40 @@
+import { inArray } from 'drizzle-orm'
+import { z } from 'zod'
+import { userTable } from '~~/server/db/pg/schema'
+import { backupKey, sessionKey } from '~~/server/utils/impersonate'
+import { getPgClient } from '~~/server/utils/pg'
+
+const DevCleanupSchema = z.object({
+  emails: z.array(z.string().email()).default([]),
+  session_ids: z.array(z.string().min(1)).default([]),
+})
+
+export default defineEventHandler(async (event) => {
+  if (!import.meta.dev) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const { emails, session_ids } = await readValidatedBody(event, DevCleanupSchema.parse)
+
+  let deletedUsers = 0
+  if (emails.length > 0) {
+    const db = getPgClient()
+    const removed = await db
+      .delete(userTable)
+      .where(inArray(userTable.primary_email, emails))
+      .returning()
+    deletedUsers = removed.length
+  }
+
+  let deletedSessions = 0
+  if (session_ids.length > 0) {
+    const storage = useStorage('redis')
+    for (const sid of session_ids) {
+      await storage.removeItem(sessionKey(sid))
+      await storage.removeItem(backupKey(sid))
+      deletedSessions++
+    }
+  }
+
+  return { deleted_users: deletedUsers, deleted_sessions: deletedSessions }
+})

--- a/server/api/auth/dev-login.post.ts
+++ b/server/api/auth/dev-login.post.ts
@@ -1,0 +1,54 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { ActivityAction, activityTable, userTable } from '~~/server/db/pg/schema'
+import { getPgClient } from '~~/server/utils/pg'
+import { simplifyNanoId } from '~~/shared/utils/id'
+
+const DevLoginSchema = z.object({
+  email: z.string().email(),
+})
+
+export default defineEventHandler(async (event) => {
+  if (!import.meta.dev) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const { email } = await readValidatedBody(event, DevLoginSchema.parse)
+  const db = getPgClient()
+
+  const [user] = await db.select().from(userTable).where(eq(userTable.primary_email, email)).limit(1)
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  const sessionId = simplifyNanoId()
+  const storage = useStorage('redis')
+
+  await storage.setItem(`session:${sessionId}`, {
+    id: user.id,
+    primary_email: user.primary_email,
+    primary_phone: user.primary_phone,
+    username: user.username,
+    name: user.name,
+    avatar: user.avatar,
+    verified: user.verified,
+    provider: 'dev-login',
+    abilities: user.abilities ?? [],
+  })
+
+  setCookie(event, 'sessionid', sessionId, {
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 7,
+    path: '/',
+  })
+
+  await db.update(userTable)
+    .set({ last_sign_in_at: new Date() })
+    .where(eq(userTable.id, user.id))
+
+  await db.insert(activityTable).values({ user_id: user.id, action: ActivityAction.SIGN_IN })
+
+  return { session_id: sessionId, user_id: user.id }
+})

--- a/server/api/auth/dev-login.post.ts
+++ b/server/api/auth/dev-login.post.ts
@@ -9,7 +9,7 @@ const DevLoginSchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  if (!import.meta.dev) {
+  if (!import.meta.dev && process.env.NUXT_DEMO_MODE !== 'true') {
     throw createError({ statusCode: 404, statusMessage: 'Not Found' })
   }
 

--- a/server/api/auth/dev-seed.post.ts
+++ b/server/api/auth/dev-seed.post.ts
@@ -4,7 +4,7 @@ import { getPgClient } from '~~/server/utils/pg'
 import { SEED_USERS } from '~~/shared/seed/users'
 
 export default defineEventHandler(async (_event) => {
-  if (!import.meta.dev) {
+  if (!import.meta.dev && process.env.NUXT_DEMO_MODE !== 'true') {
     throw createError({ statusCode: 404, statusMessage: 'Not Found' })
   }
 

--- a/server/api/auth/dev-seed.post.ts
+++ b/server/api/auth/dev-seed.post.ts
@@ -1,0 +1,43 @@
+import { eq } from 'drizzle-orm'
+import { userTable } from '~~/server/db/pg/schema'
+import { getPgClient } from '~~/server/utils/pg'
+import { SEED_USERS } from '~~/shared/seed/users'
+
+export default defineEventHandler(async (_event) => {
+  if (!import.meta.dev) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const db = getPgClient()
+  const out: Array<{ id: string, primary_email: string }> = []
+
+  for (const u of SEED_USERS) {
+    const existing = await db.select().from(userTable).where(eq(userTable.primary_email, u.primary_email)).limit(1)
+    if (existing[0]) {
+      const [updated] = await db.update(userTable)
+        .set({
+          username: u.username,
+          name: u.name,
+          primary_phone: u.primary_phone ?? null,
+          abilities: u.abilities,
+          verified: true,
+        })
+        .where(eq(userTable.id, existing[0].id))
+        .returning()
+      out.push(updated!)
+    }
+    else {
+      const [created] = await db.insert(userTable).values({
+        primary_email: u.primary_email,
+        username: u.username,
+        name: u.name,
+        primary_phone: u.primary_phone ?? null,
+        abilities: u.abilities,
+        verified: true,
+      }).returning()
+      out.push(created!)
+    }
+  }
+
+  return { users: out }
+})

--- a/server/api/auth/impersonate/start.post.ts
+++ b/server/api/auth/impersonate/start.post.ts
@@ -1,0 +1,65 @@
+import { eq } from 'drizzle-orm'
+import { ActivityAction, activityTable, userTable } from '~~/server/db/pg/schema'
+import {
+  backupKey,
+  buildImpersonatedSession,
+  IMPERSONATE_ABILITY,
+  impersonatorInfoFromSession,
+  sessionKey,
+} from '~~/server/utils/impersonate'
+import { getPgClient } from '~~/server/utils/pg'
+import { ImpersonateStartSchema } from '~~/shared/schemas/impersonate'
+
+export default defineAuthorizedHandler(
+  [IMPERSONATE_ABILITY],
+  async (event, { session }) => {
+    if (session.impersonator) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Already impersonating. Stop the current impersonation first.',
+      })
+    }
+
+    const { user_id } = await readValidatedBody(event, ImpersonateStartSchema.parse)
+
+    if (user_id === session.id) {
+      throw createError({ statusCode: 400, statusMessage: 'Cannot impersonate yourself.' })
+    }
+
+    const sessionId = getCookie(event, 'sessionid') || getHeader(event, 'x-session-id')
+    if (!sessionId) {
+      throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+    }
+
+    const db = getPgClient()
+    const [target] = await db
+      .select()
+      .from(userTable)
+      .where(eq(userTable.id, user_id))
+      .limit(1)
+
+    if (!target) {
+      throw createError({ statusCode: 404, statusMessage: 'Target user not found.' })
+    }
+
+    if (target.is_suspended) {
+      throw createError({ statusCode: 403, statusMessage: 'Cannot impersonate a suspended user.' })
+    }
+
+    const storage = useStorage('redis')
+    const impersonator = impersonatorInfoFromSession(session)
+    const newSession = buildImpersonatedSession(target, impersonator)
+
+    await storage.setItem(backupKey(sessionId), session)
+    await storage.setItem(sessionKey(sessionId), newSession)
+
+    await db.insert(activityTable).values({
+      user_id: session.id,
+      action: ActivityAction.IMPERSONATE_START,
+      action_ref_id: target.id,
+      metadata: { target_id: target.id, target_email: target.primary_email },
+    })
+
+    return newSession
+  },
+)

--- a/server/api/auth/impersonate/stop.post.ts
+++ b/server/api/auth/impersonate/stop.post.ts
@@ -1,0 +1,39 @@
+import type { AuthUser } from '~~/server/utils/auth'
+import { ActivityAction, activityTable } from '~~/server/db/pg/schema'
+import { backupKey, sessionKey } from '~~/server/utils/impersonate'
+import { getPgClient } from '~~/server/utils/pg'
+
+export default defineAuthenticatedHandler(async (event, session) => {
+  if (!session.impersonator) {
+    throw createError({ statusCode: 400, statusMessage: 'Not currently impersonating.' })
+  }
+
+  const sessionId = getCookie(event, 'sessionid') || getHeader(event, 'x-session-id')
+  if (!sessionId) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const storage = useStorage('redis')
+  const original = await storage.getItem<AuthUser>(backupKey(sessionId))
+  if (!original) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Original session backup missing. Please log in again.',
+    })
+  }
+
+  const restored: AuthUser = { ...original, impersonator: null }
+
+  await storage.setItem(sessionKey(sessionId), restored)
+  await storage.removeItem(backupKey(sessionId))
+
+  const db = getPgClient()
+  await db.insert(activityTable).values({
+    user_id: original.id,
+    action: ActivityAction.IMPERSONATE_STOP,
+    action_ref_id: session.id,
+    metadata: { target_id: session.id, target_email: session.primary_email },
+  })
+
+  return restored
+})

--- a/server/api/auth/impersonate/users.get.ts
+++ b/server/api/auth/impersonate/users.get.ts
@@ -1,0 +1,25 @@
+import { ne } from 'drizzle-orm'
+import { userTable } from '~~/server/db/pg/schema'
+import { IMPERSONATE_ABILITY } from '~~/server/utils/impersonate'
+import { getPgClient } from '~~/server/utils/pg'
+
+export default defineAuthorizedHandler(
+  [IMPERSONATE_ABILITY],
+  async (_event, { session }) => {
+    const db = getPgClient()
+    const rows = await db
+      .select({
+        id: userTable.id,
+        username: userTable.username,
+        name: userTable.name,
+        primary_email: userTable.primary_email,
+        avatar: userTable.avatar,
+        abilities: userTable.abilities,
+        is_suspended: userTable.is_suspended,
+      })
+      .from(userTable)
+      .where(ne(userTable.id, session.id))
+
+    return rows
+  },
+)

--- a/server/db/pg/migrations/0000_colorful_quasimodo.sql
+++ b/server/db/pg/migrations/0000_colorful_quasimodo.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "public"."activity_action" AS ENUM('auth:sign_in', 'auth:sign_up', 'auth:impersonate_start', 'auth:impersonate_stop');--> statement-breakpoint
+CREATE TYPE "public"."auth_provider" AS ENUM('google', 'github');--> statement-breakpoint
+CREATE TABLE "activities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"action" "activity_action" NOT NULL,
+	"action_ref_id" uuid,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "identities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" "auth_provider" NOT NULL,
+	"provider_user_id" varchar(255) NOT NULL,
+	"provider_data" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"username" varchar(64),
+	"name" varchar(255),
+	"primary_email" varchar(255) NOT NULL,
+	"primary_phone" varchar(32),
+	"avatar" varchar(2048),
+	"verified" boolean DEFAULT false,
+	"email_notifications" boolean DEFAULT true,
+	"abilities" text[] DEFAULT '{}' NOT NULL,
+	"custom_data" jsonb DEFAULT '{}'::jsonb,
+	"last_sign_in_at" timestamp with time zone,
+	"is_suspended" boolean DEFAULT false,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "users_primary_email_unique" UNIQUE("primary_email"),
+	CONSTRAINT "users_primary_phone_unique" UNIQUE("primary_phone")
+);
+--> statement-breakpoint
+ALTER TABLE "activities" ADD CONSTRAINT "activities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "identities" ADD CONSTRAINT "identities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "activities_user_id_idx" ON "activities" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "identities_user_id_idx" ON "identities" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "identities_provider_unique_idx" ON "identities" USING btree ("provider","provider_user_id");--> statement-breakpoint
+CREATE INDEX "users_username_idx" ON "users" USING btree ("username");--> statement-breakpoint
+CREATE INDEX "users_name_idx" ON "users" USING btree ("name");

--- a/server/db/pg/migrations/meta/0000_snapshot.json
+++ b/server/db/pg/migrations/meta/0000_snapshot.json
@@ -1,0 +1,380 @@
+{
+  "id": "4991ea80-4498-4dd2-8d88-a1a2021d7ff1",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "activity_action",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_ref_id": {
+          "name": "action_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activities_user_id_idx": {
+          "name": "activities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identities": {
+      "name": "identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_data": {
+          "name": "provider_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identities_user_id_idx": {
+          "name": "identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identities_provider_unique_idx": {
+          "name": "identities_provider_unique_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identities_user_id_users_id_fk": {
+          "name": "identities_user_id_users_id_fk",
+          "tableFrom": "identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_phone": {
+          "name": "primary_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "abilities": {
+          "name": "abilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "custom_data": {
+          "name": "custom_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_sign_in_at": {
+          "name": "last_sign_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_name_idx": {
+          "name": "users_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_primary_email_unique": {
+          "name": "users_primary_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "primary_email"
+          ]
+        },
+        "users_primary_phone_unique": {
+          "name": "users_primary_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "primary_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_action": {
+      "name": "activity_action",
+      "schema": "public",
+      "values": [
+        "auth:sign_in",
+        "auth:sign_up",
+        "auth:impersonate_start",
+        "auth:impersonate_stop"
+      ]
+    },
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "github"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/pg/migrations/meta/_journal.json
+++ b/server/db/pg/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777355171042,
+      "tag": "0000_colorful_quasimodo",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/db/pg/schema.ts
+++ b/server/db/pg/schema.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  text,
   timestamp,
   uniqueIndex,
   uuid,
@@ -49,6 +50,8 @@ export const providerEnum = pgEnum('auth_provider', enumToPgEnum(AuthProvider))
 export enum ActivityAction {
   SIGN_IN = 'auth:sign_in',
   SIGN_UP = 'auth:sign_up',
+  IMPERSONATE_START = 'auth:impersonate_start',
+  IMPERSONATE_STOP = 'auth:impersonate_stop',
 }
 
 export const activityActionEnum = pgEnum('activity_action', ActivityAction)
@@ -68,6 +71,7 @@ export const userTable = pgTable('users', {
   // Settings
   verified: boolean('verified').default(false),
   email_notifications: boolean('email_notifications').default(true),
+  abilities: text('abilities').array().notNull().default([]),
 
   // Metadata
   custom_data: jsonb('custom_data').default({}),

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,5 +1,13 @@
 import type { H3Event } from 'h3'
 
+export interface ImpersonatorInfo {
+  id: string
+  username: string
+  name: string
+  primary_email: string
+  abilities: string[]
+}
+
 export interface AuthUser {
   id: string
   primary_email: string
@@ -10,6 +18,7 @@ export interface AuthUser {
   verified: boolean
   provider: string
   abilities: string[]
+  impersonator?: ImpersonatorInfo | null
 }
 
 /**

--- a/server/utils/impersonate.ts
+++ b/server/utils/impersonate.ts
@@ -1,0 +1,50 @@
+import type { AuthUser, ImpersonatorInfo } from '~~/server/utils/auth'
+
+export const IMPERSONATE_ABILITY = 'user:impersonate'
+
+export function impersonatorInfoFromSession(session: AuthUser): ImpersonatorInfo {
+  return {
+    id: session.id,
+    username: session.username,
+    name: session.name,
+    primary_email: session.primary_email,
+    abilities: session.abilities,
+  }
+}
+
+export interface TargetUserRecord {
+  id: string
+  primary_email: string
+  primary_phone: string | null
+  username: string | null
+  name: string | null
+  avatar: string | null
+  verified: boolean | null
+  abilities: string[] | null
+}
+
+export function buildImpersonatedSession(
+  target: TargetUserRecord,
+  impersonator: ImpersonatorInfo,
+): AuthUser {
+  return {
+    id: target.id,
+    primary_email: target.primary_email,
+    primary_phone: target.primary_phone,
+    username: target.username ?? '',
+    name: target.name ?? '',
+    avatar: target.avatar,
+    verified: target.verified ?? false,
+    provider: 'impersonation',
+    abilities: target.abilities ?? [],
+    impersonator,
+  }
+}
+
+export function backupKey(sessionId: string): string {
+  return `impersonator:session:${sessionId}`
+}
+
+export function sessionKey(sessionId: string): string {
+  return `session:${sessionId}`
+}

--- a/shared/schemas/impersonate.ts
+++ b/shared/schemas/impersonate.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const ImpersonateStartSchema = z.object({
+  user_id: z.uuid(),
+})
+
+export type ImpersonateStartInput = z.infer<typeof ImpersonateStartSchema>

--- a/shared/seed/users.ts
+++ b/shared/seed/users.ts
@@ -1,0 +1,54 @@
+export interface SeedUserDef {
+  primary_email: string
+  username: string
+  name: string
+  primary_phone?: string | null
+  abilities: string[]
+}
+
+export const ABILITY_PRESETS = {
+  admin: [
+    'user:read',
+    'user:write',
+    'user:impersonate',
+    'todo:read',
+    'todo:write',
+    'todo:delete',
+    'blog:read',
+    'blog:write',
+  ],
+  member: [
+    'user:read',
+    'todo:read',
+    'todo:write',
+    'todo:delete:self',
+    'blog:read',
+  ],
+  guest: [
+    'blog:read',
+  ],
+} as const
+
+export const SEED_USERS: SeedUserDef[] = [
+  {
+    primary_email: 'admin@seed.local',
+    username: 'seed_admin',
+    name: 'Seed Admin',
+    primary_phone: '+10000000001',
+    abilities: [...ABILITY_PRESETS.admin],
+  },
+  {
+    primary_email: 'alice@seed.local',
+    username: 'seed_alice',
+    name: 'Seed Alice',
+    primary_phone: '+10000000002',
+    abilities: [...ABILITY_PRESETS.member],
+  },
+  {
+    primary_email: 'bob@seed.local',
+    username: 'seed_bob',
+    name: 'Seed Bob',
+    primary_phone: '+10000000003',
+    abilities: [...ABILITY_PRESETS.guest],
+  },
+]

--- a/test/nuxt/auth-store-impersonate.test.ts
+++ b/test/nuxt/auth-store-impersonate.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment nuxt
+import type { AuthUser } from '~~/server/utils/auth'
+import { describe, expect, it } from 'vitest'
+
+const ADMIN: AuthUser = {
+  id: 'admin-1',
+  primary_email: 'admin@seed.local',
+  primary_phone: null,
+  username: 'admin',
+  name: 'Admin',
+  avatar: null,
+  verified: true,
+  provider: 'google',
+  abilities: ['user:impersonate'],
+  impersonator: null,
+}
+
+const ALICE_AS_IMPERSONATED: AuthUser = {
+  ...ADMIN,
+  id: 'alice-1',
+  primary_email: 'alice@seed.local',
+  username: 'alice',
+  name: 'Alice',
+  abilities: ['todo:read'],
+  provider: 'impersonation',
+  impersonator: {
+    id: ADMIN.id,
+    username: ADMIN.username,
+    name: ADMIN.name,
+    primary_email: ADMIN.primary_email,
+    abilities: ADMIN.abilities,
+  },
+}
+
+describe('auth store — impersonation state', () => {
+  it('exposes isImpersonating=false and impersonator=null for a normal session', () => {
+    const auth = useAuthStore()
+    auth.currentUser = ADMIN
+    expect(auth.isImpersonating).toBe(false)
+    expect(auth.impersonator).toBeNull()
+  })
+
+  it('exposes isImpersonating=true and a populated impersonator while impersonating', () => {
+    const auth = useAuthStore()
+    auth.currentUser = ALICE_AS_IMPERSONATED
+    expect(auth.isImpersonating).toBe(true)
+    expect(auth.impersonator?.id).toBe('admin-1')
+    expect(auth.impersonator?.abilities).toContain('user:impersonate')
+  })
+
+  it('currentUser holds the impersonated user (NOT the admin) — so display + checks see B', () => {
+    const auth = useAuthStore()
+    auth.currentUser = ALICE_AS_IMPERSONATED
+    expect(auth.currentUser?.id).toBe('alice-1')
+    expect(auth.currentUser?.abilities).toEqual(['todo:read'])
+  })
+
+  it('returns to a clean state when currentUser is null', () => {
+    const auth = useAuthStore()
+    auth.currentUser = null
+    expect(auth.isImpersonating).toBe(false)
+    expect(auth.impersonator).toBeNull()
+  })
+})

--- a/test/nuxt/impersonate-sandbox.test.ts
+++ b/test/nuxt/impersonate-sandbox.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment nuxt
+import type { AuthUser } from '~~/server/utils/auth'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ImpersonatePage from '~/pages/sandbox/impersonate.vue'
+
+const ADMIN: AuthUser = {
+  id: 'admin-1',
+  primary_email: 'admin@seed.local',
+  primary_phone: null,
+  username: 'admin',
+  name: 'Seed Admin',
+  avatar: null,
+  verified: true,
+  provider: 'google',
+  abilities: ['user:impersonate', 'user:read'],
+  impersonator: null,
+}
+
+const ALICE_AS_IMPERSONATED: AuthUser = {
+  id: 'alice-1',
+  primary_email: 'alice@seed.local',
+  primary_phone: null,
+  username: 'alice',
+  name: 'Alice',
+  avatar: null,
+  verified: true,
+  provider: 'impersonation',
+  abilities: ['todo:read'],
+  impersonator: {
+    id: ADMIN.id,
+    username: ADMIN.username,
+    name: ADMIN.name,
+    primary_email: ADMIN.primary_email,
+    abilities: ADMIN.abilities,
+  },
+}
+
+const fetchImpersonationCandidates = vi.fn(async () => [
+  {
+    id: 'alice-1',
+    username: 'alice',
+    name: 'Alice',
+    primary_email: 'alice@seed.local',
+    avatar: null,
+    abilities: ['todo:read'],
+    is_suspended: false,
+  },
+])
+
+vi.mock('~/api/useAuthApi', () => ({
+  useAuthApi: () => ({
+    fetchImpersonationCandidates,
+    startImpersonation: vi.fn(),
+    stopImpersonation: vi.fn(),
+    fetchCurrentUser: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
+describe('impersonation sandbox page', () => {
+  beforeEach(() => {
+    fetchImpersonationCandidates.mockClear()
+  })
+
+  it('renders the heading and the candidates list', async () => {
+    const auth = useAuthStore()
+    auth.currentUser = ADMIN
+    const wrapper = await mountSuspended(ImpersonatePage)
+    const text = wrapper.text()
+    expect(text).toContain('Impersonation sandbox')
+    expect(text).toContain('Alice')
+  })
+
+  it('shows the impersonator card and badge when impersonating', async () => {
+    const auth = useAuthStore()
+    auth.currentUser = ALICE_AS_IMPERSONATED
+    const wrapper = await mountSuspended(ImpersonatePage)
+    expect(wrapper.find('[data-testid="impersonator-card"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="impersonating-badge"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="impersonator-name"]').text()).toContain('Seed Admin')
+  })
+
+  it('hides the impersonator card when not impersonating', async () => {
+    const auth = useAuthStore()
+    auth.currentUser = ADMIN
+    const wrapper = await mountSuspended(ImpersonatePage)
+    expect(wrapper.find('[data-testid="impersonator-card"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="impersonating-badge"]').exists()).toBe(false)
+  })
+
+  it('renders the current user name from the store', async () => {
+    const auth = useAuthStore()
+    auth.currentUser = ALICE_AS_IMPERSONATED
+    const wrapper = await mountSuspended(ImpersonatePage)
+    expect(wrapper.find('[data-testid="current-user-name"]').text()).toContain('Alice')
+    expect(wrapper.find('[data-testid="current-user-email"]').text()).toContain('alice@seed.local')
+  })
+})

--- a/test/unit/impersonate-roundtrip.test.ts
+++ b/test/unit/impersonate-roundtrip.test.ts
@@ -1,0 +1,109 @@
+import type { AuthUser } from '~~/server/utils/auth'
+import { describe, expect, it } from 'vitest'
+import {
+  backupKey,
+  buildImpersonatedSession,
+  impersonatorInfoFromSession,
+  sessionKey,
+} from '~~/server/utils/impersonate'
+
+class FakeStorage {
+  private map = new Map<string, unknown>()
+  async setItem(k: string, v: unknown) { this.map.set(k, v) }
+  async getItem<T>(k: string) { return (this.map.get(k) as T | undefined) ?? null }
+  async removeItem(k: string) { this.map.delete(k) }
+  has(k: string) { return this.map.has(k) }
+  size() { return this.map.size }
+}
+
+const SESSION_ID = 'sess-abc'
+
+const ADMIN: AuthUser = {
+  id: 'admin-1',
+  primary_email: 'admin@seed.local',
+  primary_phone: null,
+  username: 'admin',
+  name: 'Admin',
+  avatar: null,
+  verified: true,
+  provider: 'google',
+  abilities: ['user:impersonate', 'user:read'],
+}
+
+const TARGET = {
+  id: 'user-2',
+  primary_email: 'bob@seed.local',
+  primary_phone: null,
+  username: 'bob',
+  name: 'Bob',
+  avatar: null,
+  verified: true,
+  abilities: ['todo:read'],
+}
+
+async function start(storage: FakeStorage, sessionId: string, admin: AuthUser, target: typeof TARGET) {
+  await storage.setItem(backupKey(sessionId), admin)
+  const newSession = buildImpersonatedSession(target, impersonatorInfoFromSession(admin))
+  await storage.setItem(sessionKey(sessionId), newSession)
+  return newSession
+}
+
+async function stop(storage: FakeStorage, sessionId: string) {
+  const original = await storage.getItem<AuthUser>(backupKey(sessionId))
+  if (!original)
+    throw new Error('Backup missing')
+  const restored = { ...original, impersonator: null }
+  await storage.setItem(sessionKey(sessionId), restored)
+  await storage.removeItem(backupKey(sessionId))
+  return restored
+}
+
+describe('impersonation session roundtrip', () => {
+  it('start: replaces session with target user and backs up admin', async () => {
+    const storage = new FakeStorage()
+    await storage.setItem(sessionKey(SESSION_ID), ADMIN)
+
+    const after = await start(storage, SESSION_ID, ADMIN, TARGET)
+
+    expect(after.id).toBe(TARGET.id)
+    expect(after.abilities).toEqual(['todo:read'])
+    expect(after.impersonator?.id).toBe(ADMIN.id)
+
+    const live = await storage.getItem<AuthUser>(sessionKey(SESSION_ID))
+    expect(live?.id).toBe(TARGET.id)
+
+    const backup = await storage.getItem<AuthUser>(backupKey(SESSION_ID))
+    expect(backup?.id).toBe(ADMIN.id)
+    expect(backup?.abilities).toContain('user:impersonate')
+  })
+
+  it('stop: restores admin and removes backup', async () => {
+    const storage = new FakeStorage()
+    await storage.setItem(sessionKey(SESSION_ID), ADMIN)
+    await start(storage, SESSION_ID, ADMIN, TARGET)
+
+    const restored = await stop(storage, SESSION_ID)
+
+    expect(restored.id).toBe(ADMIN.id)
+    expect(restored.abilities).toContain('user:impersonate')
+    expect(restored.impersonator).toBeNull()
+
+    const live = await storage.getItem<AuthUser>(sessionKey(SESSION_ID))
+    expect(live?.id).toBe(ADMIN.id)
+    expect(storage.has(backupKey(SESSION_ID))).toBe(false)
+  })
+
+  it('stop: throws when no backup exists (e.g. tampering or already stopped)', async () => {
+    const storage = new FakeStorage()
+    await expect(stop(storage, SESSION_ID)).rejects.toThrow(/missing/i)
+  })
+
+  it('an impersonated session evaluates abilities as the target user', async () => {
+    const storage = new FakeStorage()
+    await start(storage, SESSION_ID, ADMIN, TARGET)
+    const live = await storage.getItem<AuthUser>(sessionKey(SESSION_ID))
+
+    expect(live?.abilities.includes('user:impersonate')).toBe(false)
+    expect(live?.abilities.includes('todo:read')).toBe(true)
+  })
+})

--- a/test/unit/impersonate-utils.test.ts
+++ b/test/unit/impersonate-utils.test.ts
@@ -1,0 +1,122 @@
+import type { AuthUser } from '~~/server/utils/auth'
+import { describe, expect, it } from 'vitest'
+import {
+  backupKey,
+  buildImpersonatedSession,
+  IMPERSONATE_ABILITY,
+  impersonatorInfoFromSession,
+  sessionKey,
+} from '~~/server/utils/impersonate'
+import { ImpersonateStartSchema } from '~~/shared/schemas/impersonate'
+
+function makeAdmin(over: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    primary_email: 'admin@seed.local',
+    primary_phone: null,
+    username: 'admin',
+    name: 'Seed Admin',
+    avatar: null,
+    verified: true,
+    provider: 'google',
+    abilities: ['user:impersonate', 'user:read'],
+    ...over,
+  }
+}
+
+function makeTarget(over: Record<string, unknown> = {}) {
+  return {
+    id: '7f3c1c4e-2c4e-4d4d-9d4e-2c4e4d4d9d4e',
+    primary_email: 'alice@seed.local',
+    primary_phone: '+10000000002',
+    username: 'alice',
+    name: 'Alice',
+    avatar: null,
+    verified: true,
+    abilities: ['todo:read', 'todo:write'],
+    ...over,
+  } as Parameters<typeof buildImpersonatedSession>[0]
+}
+
+describe('impersonate ability constant', () => {
+  it('exposes the canonical ability string', () => {
+    expect(IMPERSONATE_ABILITY).toBe('user:impersonate')
+  })
+})
+
+describe('impersonatorInfoFromSession', () => {
+  it('extracts identity + abilities for the backup record', () => {
+    const admin = makeAdmin()
+    expect(impersonatorInfoFromSession(admin)).toEqual({
+      id: admin.id,
+      username: admin.username,
+      name: admin.name,
+      primary_email: admin.primary_email,
+      abilities: admin.abilities,
+    })
+  })
+
+  it('does not include the impersonator field itself (no nesting)', () => {
+    const admin = makeAdmin({ impersonator: null })
+    const info = impersonatorInfoFromSession(admin)
+    expect('impersonator' in info).toBe(false)
+  })
+})
+
+describe('buildImpersonatedSession', () => {
+  it('returns the target user as the new session, with impersonator attached', () => {
+    const admin = makeAdmin()
+    const target = makeTarget()
+    const session = buildImpersonatedSession(target, impersonatorInfoFromSession(admin))
+
+    expect(session.id).toBe(target.id)
+    expect(session.primary_email).toBe(target.primary_email)
+    expect(session.abilities).toEqual(['todo:read', 'todo:write'])
+    expect(session.impersonator?.id).toBe(admin.id)
+    expect(session.impersonator?.abilities).toContain('user:impersonate')
+  })
+
+  it('sets provider to "impersonation" so it is distinguishable from a real login', () => {
+    const session = buildImpersonatedSession(makeTarget(), impersonatorInfoFromSession(makeAdmin()))
+    expect(session.provider).toBe('impersonation')
+  })
+
+  it('coerces null target abilities to an empty array', () => {
+    const session = buildImpersonatedSession(
+      makeTarget({ abilities: null }),
+      impersonatorInfoFromSession(makeAdmin()),
+    )
+    expect(session.abilities).toEqual([])
+  })
+
+  it('coerces null username/name to empty strings (AuthUser requires strings)', () => {
+    const session = buildImpersonatedSession(
+      makeTarget({ username: null, name: null }),
+      impersonatorInfoFromSession(makeAdmin()),
+    )
+    expect(session.username).toBe('')
+    expect(session.name).toBe('')
+  })
+})
+
+describe('redis key helpers', () => {
+  it('returns deterministic keys for a session id', () => {
+    expect(sessionKey('abc123')).toBe('session:abc123')
+    expect(backupKey('abc123')).toBe('impersonator:session:abc123')
+  })
+})
+
+describe('impersonate start schema', () => {
+  it('accepts a valid uuid', () => {
+    const parsed = ImpersonateStartSchema.parse({ user_id: '7f3c1c4e-2c4e-4d4d-9d4e-2c4e4d4d9d4e' })
+    expect(parsed.user_id).toBe('7f3c1c4e-2c4e-4d4d-9d4e-2c4e4d4d9d4e')
+  })
+
+  it('rejects a non-uuid user_id', () => {
+    expect(() => ImpersonateStartSchema.parse({ user_id: 'not-a-uuid' })).toThrow()
+  })
+
+  it('rejects when user_id is missing', () => {
+    expect(() => ImpersonateStartSchema.parse({})).toThrow()
+  })
+})

--- a/test/unit/seed.test.ts
+++ b/test/unit/seed.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { ABILITY_PRESETS, SEED_USERS } from '~~/shared/seed/users'
+
+describe('ability presets', () => {
+  it('grants user:impersonate to the admin preset', () => {
+    expect(ABILITY_PRESETS.admin).toContain('user:impersonate')
+  })
+
+  it('does NOT grant user:impersonate to non-admin presets', () => {
+    expect(ABILITY_PRESETS.member).not.toContain('user:impersonate')
+    expect(ABILITY_PRESETS.guest).not.toContain('user:impersonate')
+  })
+
+  it('uses the canonical "subject:action" or "subject:action:scope" format for every ability', () => {
+    const all = [...ABILITY_PRESETS.admin, ...ABILITY_PRESETS.member, ...ABILITY_PRESETS.guest]
+    for (const a of all) {
+      expect(a).toMatch(/^[a-z]+:[a-z]+(:self)?$/)
+    }
+  })
+})
+
+describe('seed users', () => {
+  it('seeds exactly one admin user with the impersonate ability', () => {
+    const admins = SEED_USERS.filter(u => u.abilities.includes('user:impersonate'))
+    expect(admins).toHaveLength(1)
+    expect(admins[0]!.primary_email).toBe('admin@seed.local')
+  })
+
+  it('uses the @seed.local email suffix so cleanup is unambiguous', () => {
+    for (const u of SEED_USERS) {
+      expect(u.primary_email).toMatch(/@seed\.local$/)
+    }
+  })
+
+  it('every seed user has a unique email', () => {
+    const emails = SEED_USERS.map(u => u.primary_email)
+    expect(new Set(emails).size).toBe(emails.length)
+  })
+})

--- a/tests/impersonate.e2e.ts
+++ b/tests/impersonate.e2e.ts
@@ -1,0 +1,176 @@
+import type { APIRequestContext } from '@playwright/test'
+import { expect, test } from '@nuxt/test-utils/playwright'
+import { SEED_USERS } from '../shared/seed/users'
+
+const ADMIN_EMAIL = 'admin@seed.local'
+const ALICE_EMAIL = 'alice@seed.local'
+const BOB_EMAIL = 'bob@seed.local'
+const FORBIDDEN_URL = /\/forbidden$/
+
+const issuedSessionIds = new Set<string>()
+
+async function devSeed(request: APIRequestContext) {
+  const res = await request.post('/api/auth/dev-seed')
+  expect(res.ok()).toBeTruthy()
+  return res.json() as Promise<{ users: Array<{ id: string, primary_email: string }> }>
+}
+
+async function devLogin(request: APIRequestContext, email: string) {
+  const res = await request.post('/api/auth/dev-login', { data: { email } })
+  expect(res.ok()).toBeTruthy()
+  const body = (await res.json()) as { session_id: string, user_id: string }
+  issuedSessionIds.add(body.session_id)
+  return body
+}
+
+async function devCleanup(request: APIRequestContext) {
+  await request.post('/api/auth/dev-cleanup', {
+    data: {
+      emails: SEED_USERS.map(u => u.primary_email),
+      session_ids: Array.from(issuedSessionIds),
+    },
+  })
+  issuedSessionIds.clear()
+}
+
+test.describe('impersonation', () => {
+  test.beforeAll(async ({ request }) => {
+    await devSeed(request)
+  })
+
+  test.afterAll(async ({ request }) => {
+    await devCleanup(request)
+  })
+
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies()
+  })
+
+  test('non-admin is redirected to /forbidden when visiting the sandbox', async ({ page, context, request, baseURL }) => {
+    const { session_id } = await devLogin(request, BOB_EMAIL)
+    await context.addCookies([{
+      name: 'sessionid',
+      value: session_id,
+      url: baseURL!,
+      httpOnly: true,
+      sameSite: 'Lax',
+    }])
+
+    await page.goto('/sandbox/impersonate')
+    await expect(page).toHaveURL(FORBIDDEN_URL)
+  })
+
+  test('admin can impersonate alice; session swaps + banner appears', async ({ page, context, request, baseURL }) => {
+    const { session_id } = await devLogin(request, ADMIN_EMAIL)
+    await context.addCookies([{
+      name: 'sessionid',
+      value: session_id,
+      url: baseURL!,
+      httpOnly: true,
+      sameSite: 'Lax',
+    }])
+
+    await page.goto('/sandbox/impersonate', { waitUntil: 'hydration' })
+    await expect(page.getByRole('heading', { name: 'Impersonation sandbox' })).toBeVisible()
+    await expect(page.getByTestId('current-user-name')).toContainText('Seed Admin')
+
+    await page.getByTestId(`impersonate-${ALICE_EMAIL}`).click()
+
+    await expect(page.getByTestId('global-impersonation-banner')).toBeVisible()
+    await expect(page.getByTestId('impersonating-badge')).toBeVisible()
+    await expect(page.getByTestId('current-user-name')).toContainText('Seed Alice')
+    await expect(page.getByTestId('impersonator-email')).toContainText(ADMIN_EMAIL)
+
+    // Server-side: /api/auth/me should now return alice with impersonator info
+    const meRes = await request.get('/api/auth/me', {
+      headers: { 'x-session-id': session_id },
+    })
+    const me = (await meRes.json()) as { id: string, primary_email: string, impersonator: { primary_email: string } | null }
+    expect(me.primary_email).toBe(ALICE_EMAIL)
+    expect(me.impersonator?.primary_email).toBe(ADMIN_EMAIL)
+  })
+
+  test('redirection block: after impersonating bob (no impersonate ability), the sandbox redirects to /forbidden', async ({ page, context, request, baseURL }) => {
+    const { session_id } = await devLogin(request, ADMIN_EMAIL)
+    await context.addCookies([{
+      name: 'sessionid',
+      value: session_id,
+      url: baseURL!,
+      httpOnly: true,
+      sameSite: 'Lax',
+    }])
+
+    await page.goto('/sandbox/impersonate', { waitUntil: 'hydration' })
+    await page.getByTestId(`impersonate-${BOB_EMAIL}`).click()
+    await expect(page.getByTestId('global-impersonation-banner')).toBeVisible()
+
+    // Now navigate away and back — Bob has no user:impersonate, so casl middleware redirects.
+    await page.goto('/sandbox/impersonate')
+    await expect(page).toHaveURL(FORBIDDEN_URL)
+  })
+
+  test('stop impersonation restores the admin session', async ({ page, context, request, baseURL }) => {
+    const { session_id } = await devLogin(request, ADMIN_EMAIL)
+    await context.addCookies([{
+      name: 'sessionid',
+      value: session_id,
+      url: baseURL!,
+      httpOnly: true,
+      sameSite: 'Lax',
+    }])
+
+    await page.goto('/sandbox/impersonate', { waitUntil: 'hydration' })
+    await page.getByTestId(`impersonate-${ALICE_EMAIL}`).click()
+    await expect(page.getByTestId('global-impersonation-banner')).toBeVisible()
+
+    await page.getByTestId('banner-stop-impersonation').click()
+    await expect(page.getByTestId('global-impersonation-banner')).toBeHidden()
+    await expect(page.getByTestId('current-user-name')).toContainText('Seed Admin')
+
+    // Server-side verification
+    const meRes = await request.get('/api/auth/me', {
+      headers: { 'x-session-id': session_id },
+    })
+    const me = (await meRes.json()) as { primary_email: string, impersonator: unknown }
+    expect(me.primary_email).toBe(ADMIN_EMAIL)
+    expect(me.impersonator).toBeNull()
+  })
+
+  test('cannot start impersonation while already impersonating', async ({ request }) => {
+    const { session_id, user_id: adminId } = await devLogin(request, ADMIN_EMAIL)
+    const { user_id: aliceId } = await devLogin(request, ALICE_EMAIL)
+    void adminId
+
+    const start1 = await request.post('/api/auth/impersonate/start', {
+      headers: { 'x-session-id': session_id },
+      data: { user_id: aliceId },
+    })
+    expect(start1.ok()).toBeTruthy()
+
+    const start2 = await request.post('/api/auth/impersonate/start', {
+      headers: { 'x-session-id': session_id },
+      data: { user_id: aliceId },
+    })
+    expect(start2.status()).toBe(400)
+  })
+
+  test('cannot self-impersonate', async ({ request }) => {
+    const { session_id, user_id } = await devLogin(request, ADMIN_EMAIL)
+    const res = await request.post('/api/auth/impersonate/start', {
+      headers: { 'x-session-id': session_id },
+      data: { user_id },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('non-admin server call to /api/auth/impersonate/start returns 403', async ({ request }) => {
+    const { session_id } = await devLogin(request, BOB_EMAIL)
+    const { user_id: aliceId } = await devLogin(request, ALICE_EMAIL)
+
+    const res = await request.post('/api/auth/impersonate/start', {
+      headers: { 'x-session-id': session_id },
+      data: { user_id: aliceId },
+    })
+    expect(res.status()).toBe(403)
+  })
+})


### PR DESCRIPTION
- Adds POST /api/auth/impersonate/{start,stop} that swap the Redis
  session in-place: admin's session is backed up at
  impersonator:session:{sid}, the live session becomes the target user
  (with their abilities), so every server + client authorization check
  reflects the impersonated user. Stop restores from the backup.
- AuthUser gains an optional `impersonator` field carrying the original
  admin's identity + abilities for the UI.
- Pinia auth store exposes `currentUser` (= impersonated user), a
  computed `impersonator`, and `isImpersonating`, plus
  start/stopImpersonation actions.
- Sandbox at /sandbox/impersonate (gated by `user:impersonate`) lists
  users and triggers impersonation; a global ImpersonationBanner
  renders on every page so the admin can stop after losing access to
  the gated sandbox.
- Adds an `abilities` text[] column on users (stored authoritatively
  in DB, materialised into the session at login). Seeder script
  (pnpm db:seed) creates admin/member/guest presets where only admin
  carries `user:impersonate`.
- Dev-only endpoints (dev-login, dev-seed, dev-cleanup) gate behind
  import.meta.dev so e2e tests can seed, log in as a specific user,
  and tear down both DB rows and Redis sessions for full cleanup.
- Vitest covers session-swap helpers, Zod schema, the roundtrip with
  an in-memory Redis stub, the Pinia computed state, the sandbox page,
  and the seed presets. Playwright covers the redirect-block flow
  (Bob lacks the ability → /forbidden after impersonation), 403 for
  non-admins, no self-impersonation, no double-impersonation, and
  full stop/restore.

https://claude.ai/code/session_01MruNX6MWfYqNZS4tDLDf5B